### PR TITLE
".loci" files are hell to navigate

### DIFF
--- a/alignable.py
+++ b/alignable.py
@@ -500,6 +500,7 @@ def makealign(ingroup, minspecies, outname, infile,
     infile.close()
     outfile.close()
 
+
 def DoStats(ingroup, outgroups, outname, 
             WORK, minspecies,longname):
 

--- a/alignable.py
+++ b/alignable.py
@@ -480,26 +480,37 @@ def makealign(ingroup, minspecies, outname, infile,
     for handle in glob.glob(WORK+".chunk*"):
         locus += int(result_queue.get())
 
-    " output stats and delete temp files... "
-    cmd = "/bin/cat "+WORK+".align* > "+WORK+"outfiles/"+outname+".loci"
-    os.system(cmd)                      ## outname add
-    os.system("/bin/rm "+WORK+".align* "+WORK+".chunk*")
-    cmd = "/bin/cat "+WORK+".not* > "+WORK+"outfiles/"+outname+".excluded_loci"
-    os.system(cmd)                      ## outname add
-    os.system("/bin/rm "+WORK+".not*")
+
+    " output loci and excluded loci and delete temp files... "
 
     locicounter = 1
-    infile = open(WORK+"outfiles/"+outname+".loci", 'r')
-    outfile = open(WORK+"outfiles/"+outname+".numberedloci", 'w')
-    for lines in infile:
-        if lines.startswith("//"):
-            lines = lines.replace(" " * len(str(locicounter)), str(locicounter), 1)
-            locicounter += 1
-	outfile.write(lines)
-        
-    infile.close()
-    outfile.close()
-
+    aligns = glob.glob(WORK+".align*")
+    locifile = open(WORK+"outfiles/"+outname+".loci", "w")
+    
+    for chunkfile in aligns:
+        chunkdata = open(chunkfile, "r")
+        for lines in chunkdata:
+            if lines.startswith("//"):
+                lines = lines.replace("|\n", "|"+str(locicounter)+"\n", 1)
+                locicounter += 1
+            locifile.write(lines)
+        chunkdata.close()
+        os.remove(chunkfile)
+    
+    locifile.close()
+    
+    unaligns = glob.glob(WORK+".not*")
+    excluded_loci_file = open(WORK+"outfiles/"+outname+".excluded_loci", "w")
+    
+    for excludechunk in unaligns:
+        excludedata = open(excludechunk, "r")
+        for lines in excludedata:
+            excluded_loci_file.write(lines)
+        excludedata.close()
+        os.remove(excludechunk)
+    
+    excluded_loci_file.close()
+    
 
 def DoStats(ingroup, outgroups, outname, 
             WORK, minspecies,longname):

--- a/alignable.py
+++ b/alignable.py
@@ -488,6 +488,17 @@ def makealign(ingroup, minspecies, outname, infile,
     os.system(cmd)                      ## outname add
     os.system("/bin/rm "+WORK+".not*")
 
+    locicounter = 1
+    infile = open(WORK+"outfiles/"+outname+".loci", 'r')
+    outfile = open(WORK+"outfiles/"+outname+".numberedloci", 'w')
+    for lines in infile:
+        if lines.startswith("//"):
+            lines = lines.replace(" " * len(str(locicounter)), str(locicounter), 1)
+            locicounter += 1
+	outfile.write(lines)
+        
+    infile.close()
+    outfile.close()
 
 def DoStats(ingroup, outgroups, outname, 
             WORK, minspecies,longname):


### PR DESCRIPTION
Especially when comparing with the data in the VCF file.
I have made changes to `alignable.py` to output a file named ".numberedloci" which is the same as the .loci, only it contains the loci number after the "//" splitter.
I had concerns about space, but for an analysis with 3 letter taxa, you can accomodate up to 6 digits number loci, which I would say accounts for 99.9% of the cases.
If you think it is redundant with the ".loci" designation, let me know and I will simply replace the old implementation with the new one (effectively getting rid of the "//" without numbering).