### PR TITLE
Updated MUSCLE download link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ You will need the following two Python dependencies with `pyrad`.
 
 In addition to the programs  
 
- * `muscle <www.drive5.com/muscle/downloads>`_
+ * `muscle <http://www.drive5.com/muscle/downloads.htm>`_
  * `vsearch <https://github.com/torognes/vsearch>`_
 
 Example usage (see tutorials)


### PR DESCRIPTION
Hi, Dr. Eaton. Here's a minor touch-up to `README.rst` that updates the MUSCLE download link (was a 404 before).

On a side note: `README.rst` is actually a bit tough to follow when reading in a terminal environment. I know it's a *super* minor thing, but if you have no strong aversion to it, I'll happily wrap it at 78-ish columns, trim the extra whitespace, and re-do this pull request.

I won't rule out the possibility that I'm just demonstrating a degree of ignorance about the format (coming from a Markdown background), but this less "spacious" version [still renders more-or-less-okay in an online RST editor](http://rst.ninjs.org/?n=b3be7d4c6182d8aa00c18241e703fe62&theme=nature), anyway.

![trimmed_ws](https://cloud.githubusercontent.com/assets/4009681/13638413/76ad30ea-e60c-11e5-85e3-88f158fedc56.png)