### PR TITLE
Fixing newline formatting in VCF

### DIFF
--- a/pyrad/loci2vcf.py
+++ b/pyrad/loci2vcf.py
@@ -61,7 +61,7 @@ def make(WORK, version, outname, mindepth, names):
                             GENOS.append("./.")
                     vcflist.append("\t".join([`locusnumber+1`, `base+1`, '.', REF, ",".join(ALT), "20", "PASS",
                                               ";".join(["NS="+NS, "DP="+DP]), "GT"]+GENOS))
-        if not locusnumber % 1000:
+        if vcflist and not locusnumber % 1000:
             outfile.write( "\n".join(vcflist)+"\n" )
             vcflist = []
                                               
@@ -69,7 +69,7 @@ def make(WORK, version, outname, mindepth, names):
                     #                            ";".join(["NS="+NS, "DP="+DP]), "GT"]+GENOS)
     
 
-    outfile.write( "\n".join(vcflist) )
+    outfile.write( "\n".join(vcflist)+"\n" )
     outfile.close()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, if the first locus in .loci does not contain a polymorphic site then the first line after the header is a blank line. Changed loci2vcf.py here in line 64 to check to make sure 'vcflist' evaluates to TRUE (is not empty) before printing in line 65 (as "not 0 % 1000" evaluates to TRUE).

Also added a newline write to line 72 so that the file ends in a newline character for POSIX compliance and to enable compatibility with the VCF parser in the R package SNPRelate (snpgdsVCF2gds).

Thanks!
Evan
